### PR TITLE
feat: add redact (mosaic) annotation tool

### DIFF
--- a/src/components/Canvas.tsx
+++ b/src/components/Canvas.tsx
@@ -10,6 +10,7 @@ import {
   drawText,
   drawArrow,
   drawFilledRect,
+  drawRedact,
 } from 'src/utils/canvas'
 import { useStore } from 'src/store'
 import * as t from 'src/types'
@@ -104,6 +105,22 @@ export function Canvas() {
         h: height / 3,
         // TODO: enable to change this
         fill: '#000',
+      },
+    ])
+    setFocsedElementIndex(elements.length)
+    setIsFocus(true)
+  })
+
+  useKeyPress(['m'], () => {
+    const { width, height } = canvasRef.current
+    setElements([
+      ...elements,
+      {
+        type: 'REDACT',
+        x: width / 3,
+        y: height / 3,
+        w: width / 3,
+        h: height / 3,
       },
     ])
     setFocsedElementIndex(elements.length)
@@ -512,6 +529,16 @@ export function Canvas() {
           element.y,
           element.fontSize,
           element.content,
+          isFocus && index === focusedElementIndex,
+        )
+      }
+      if (t.isRedact(element)) {
+        drawRedact(
+          ctx,
+          element.x,
+          element.y,
+          element.w,
+          element.h,
           isFocus && index === focusedElementIndex,
         )
       }

--- a/src/components/Help.tsx
+++ b/src/components/Help.tsx
@@ -13,6 +13,7 @@ const shortcuts = [
   },
   { key: 'Ctrl + c', description: 'Copy the image on the canvas to clipboard' },
   { key: 'r', description: 'Add a rectangle on the canvas' },
+  { key: 'm', description: 'Add a redact (mosaic) rectangle on the canvas' },
   { key: 'a', description: 'Add an arrow on the canvas' },
   {
     key: 't',

--- a/src/components/QuickHelp.tsx
+++ b/src/components/QuickHelp.tsx
@@ -10,6 +10,7 @@ export function QuickHelp() {
     <div className="fixed left-0 bottom-0 w-full py-2 invert-if-dark">
       <div className="flex items-center justify-end">
         <Desc k="r" desc="Rectangle" />
+        <Desc k="m" desc="Redact" />
         <Desc k="t" desc="Text" />
         <Desc k="o" desc="select Other" />
         <Desc k="&larr;&uarr;&darr;&rarr;" desc="Move" />

--- a/src/types.ts
+++ b/src/types.ts
@@ -44,8 +44,18 @@ export function isArrow(e: any): e is Arrow {
   return e.type === 'ARROW'
 }
 
-export function isAbleToResize(e: any): e is Rectangle {
-  return isRectangle(e) || isArrow(e) || isFilledRectangle(e)
+export interface Redact extends CanvasElement {
+  type: 'REDACT'
+  w: number
+  h: number
 }
 
-export type RenderedElement = Rectangle | Text | Arrow | FilledRectangle
+export function isRedact(e: any): e is Redact {
+  return e.type === 'REDACT'
+}
+
+export function isAbleToResize(e: any): e is Rectangle {
+  return isRectangle(e) || isArrow(e) || isFilledRectangle(e) || isRedact(e)
+}
+
+export type RenderedElement = Rectangle | Text | Arrow | FilledRectangle | Redact

--- a/src/utils/canvas.ts
+++ b/src/utils/canvas.ts
@@ -75,6 +75,71 @@ export function drawText(
   ctx.strokeText(content, x, y)
 }
 
+export function drawRedact(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  isFocused?: boolean,
+) {
+  const blockSize = 12
+  const ix = Math.max(0, Math.round(x))
+  const iy = Math.max(0, Math.round(y))
+  const iw = Math.round(width)
+  const ih = Math.round(height)
+
+  const canvas = ctx.canvas
+  const clampedW = Math.min(iw, canvas.width - ix)
+  const clampedH = Math.min(ih, canvas.height - iy)
+  if (clampedW <= 0 || clampedH <= 0) return
+
+  const imageData = ctx.getImageData(ix, iy, clampedW, clampedH)
+  const data = imageData.data
+
+  for (let by = 0; by < clampedH; by += blockSize) {
+    for (let bx = 0; bx < clampedW; bx += blockSize) {
+      const bw = Math.min(blockSize, clampedW - bx)
+      const bh = Math.min(blockSize, clampedH - by)
+      let r = 0,
+        g = 0,
+        b = 0,
+        count = 0
+      for (let py = by; py < by + bh; py++) {
+        for (let px = bx; px < bx + bw; px++) {
+          const i = (py * clampedW + px) * 4
+          r += data[i]!
+          g += data[i + 1]!
+          b += data[i + 2]!
+          count++
+        }
+      }
+      r = Math.round(r / count)
+      g = Math.round(g / count)
+      b = Math.round(b / count)
+      for (let py = by; py < by + bh; py++) {
+        for (let px = bx; px < bx + bw; px++) {
+          const i = (py * clampedW + px) * 4
+          data[i] = r
+          data[i + 1] = g
+          data[i + 2] = b
+        }
+      }
+    }
+  }
+
+  ctx.putImageData(imageData, ix, iy)
+
+  if (isFocused) {
+    const settings = getState().settings
+    ctx.strokeStyle = settings.secondaryColor
+    ctx.lineWidth = 4
+    ctx.setLineDash([8, 4])
+    ctx.strokeRect(ix, iy, clampedW, clampedH)
+    ctx.setLineDash([])
+  }
+}
+
 export function getElementDimension(elm: t.RenderedElement) {
   if (t.isRectangle(elm)) {
     return { w: elm.w, h: elm.h }


### PR DESCRIPTION
## Summary
- Add a new `Redact` element type that pixelates the underlying image region using a 12px block mosaic effect
- Bound to the `m` key, supports all existing move/resize keyboard shortcuts (same as rectangles)
- Shows a dashed border when focused for visual feedback

## Test plan
- [ ] Paste an image, press `m` to add a redact rectangle
- [ ] Verify the region underneath is pixelated with a mosaic effect
- [ ] Move the redact element with arrow keys / vim keys and confirm the mosaic updates correctly
- [ ] Resize the redact element with Shift + arrow keys and confirm it works
- [ ] Press `?` and verify the `m` shortcut appears in the help cheatsheet
- [ ] Verify the quick help bar at the bottom shows the `m` / Redact hint
- [ ] Copy/download the image and confirm the mosaic is baked into the output

🤖 Generated with [Claude Code](https://claude.com/claude-code)