### PR TITLE
feat: add undo/redo support with Ctrl+Z / Ctrl+Shift+Z

### DIFF
--- a/src/components/Canvas.tsx
+++ b/src/components/Canvas.tsx
@@ -4,6 +4,7 @@ import dayjs from 'dayjs'
 import { useCanvasContext } from 'src/hooks/useCanvasContext'
 import { useOnPasteImage } from 'src/hooks/useOnPasteImage'
 import { useKeyPress } from 'src/hooks/useKeyPress'
+import { useHistory } from 'src/hooks/useHistory'
 import {
   getElementDimension,
   drawRoundedRect,
@@ -20,7 +21,7 @@ const DEFAULT_RECT_ROUND = 3
 export function Canvas() {
   const settings = useStore((state) => state.settings)
   const canvasRef = useRef<any>(null)
-  const [elements, setElements] = useState<t.RenderedElement[]>([])
+  const [elements, setElements, undo, redo] = useHistory<t.RenderedElement[]>([])
   const [focusedElementIndex, setFocsedElementIndex] = useState(0)
   const [isFocus, setIsFocus] = useState(false)
   const [isInputVisilble, setIsInputVisible] = useState(false)
@@ -66,6 +67,22 @@ export function Canvas() {
       navigator.clipboard.write([item])
       toast.success('Copied to clipboard')
     })
+  })
+
+  useKeyPress(['ctrl.z', 'meta.z'], (event) => {
+    event.preventDefault()
+    const prev = undo()
+    if (prev) {
+      setFocsedElementIndex(Math.min(focusedElementIndex, Math.max(0, prev.length - 1)))
+    }
+  })
+
+  useKeyPress(['ctrl.shift.Z', 'meta.shift.Z'], (event) => {
+    event.preventDefault()
+    const next = redo()
+    if (next) {
+      setFocsedElementIndex(Math.min(focusedElementIndex, Math.max(0, next.length - 1)))
+    }
   })
 
   useKeyPress(['shift.D', 'ctrl.s'], (event) => {

--- a/src/hooks/useHistory.ts
+++ b/src/hooks/useHistory.ts
@@ -1,0 +1,45 @@
+import { useCallback, useRef, useState } from 'react'
+
+export function useHistory<T>(initialState: T) {
+  const [state, setStateInternal] = useState(initialState)
+  const historyRef = useRef<T[]>([initialState])
+  const pointerRef = useRef(0)
+
+  const setState = useCallback((updater: T | ((prev: T) => T)) => {
+    setStateInternal((prev) => {
+      const next =
+        typeof updater === 'function'
+          ? (updater as (prev: T) => T)(prev)
+          : updater
+      historyRef.current = historyRef.current.slice(
+        0,
+        pointerRef.current + 1,
+      )
+      historyRef.current.push(next)
+      pointerRef.current = historyRef.current.length - 1
+      return next
+    })
+  }, [])
+
+  const undo = useCallback((): T | null => {
+    if (pointerRef.current > 0) {
+      pointerRef.current--
+      const prev = historyRef.current[pointerRef.current]!
+      setStateInternal(prev)
+      return prev
+    }
+    return null
+  }, [])
+
+  const redo = useCallback((): T | null => {
+    if (pointerRef.current < historyRef.current.length - 1) {
+      pointerRef.current++
+      const next = historyRef.current[pointerRef.current]!
+      setStateInternal(next)
+      return next
+    }
+    return null
+  }, [])
+
+  return [state, setState, undo, redo] as const
+}


### PR DESCRIPTION
## Summary
- Add `useHistory` hook — plain array + pointer pattern that wraps `useState` with undo/redo capability
- Wire `Ctrl+Z` / `Cmd+Z` for undo and `Ctrl+Shift+Z` / `Cmd+Shift+Z` for redo on the elements state
- Focused element index is clamped after undo/redo to stay within bounds

## Test plan
- [ ] Paste an image, add several annotations (rect, text, arrow), then Ctrl+Z to undo each
- [ ] Ctrl+Shift+Z to redo undone actions
- [ ] After undoing, add a new annotation — verify redo history is cleared
- [ ] Verify undo at the beginning and redo at the end are no-ops
- [ ] Verify Ctrl+Z inside text input triggers browser native undo (not annotation undo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)