### PR TITLE
Fix Japanese text rendering on canvas

### DIFF
--- a/src/utils/canvas.ts
+++ b/src/utils/canvas.ts
@@ -66,13 +66,13 @@ export function drawText(
   isFocused?: boolean,
 ) {
   const settings = getState().settings
-  ctx.font = `bold ${fontSize}px sans`
-  ctx.fillStyle = isFocused ? settings.secondaryColor : settings.primaryColor
-  ctx.fillText(content, x, y)
+  ctx.font = `bold ${fontSize}px sans-serif`
   ctx.strokeStyle = '#fff'
   ctx.lineWidth = fontSize / 37
   ctx.lineCap = 'round'
   ctx.strokeText(content, x, y)
+  ctx.fillStyle = isFocused ? settings.secondaryColor : settings.primaryColor
+  ctx.fillText(content, x, y)
 }
 
 export function drawRedact(


### PR DESCRIPTION
## Summary
- Use correct CSS generic font family `sans-serif` instead of `sans`, which caused fallback to a font lacking proper CJK glyph support
- Draw the white stroke outline **before** the color fill so complex Japanese characters are not partially obscured by the outline layer

## Test plan
- [ ] Paste an image and add a text annotation with Japanese characters — verify they render cleanly
- [ ] Verify English text still renders correctly with the outline effect

🤖 Generated with [Claude Code](https://claude.com/claude-code)